### PR TITLE
Keep the CLI feature of KeePassXC

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -59,7 +59,6 @@ modules:
           install -Dm644 $f /app/share/licenses/org.keepassxc.KeePassXC/$f
         done
     cleanup:
-      - /bin/keepassxc-cli
       - /share/man
     modules:
 


### PR DESCRIPTION
We can use it via `flatpak run --command=keepassxc-cli org.keepassxc.KeePassXC --help`, which is sometimes useful