### PR TITLE
Fix KeePassXC-Browser support

### DIFF
--- a/command-wrapper.sh
+++ b/command-wrapper.sh
@@ -1,0 +1,18 @@
+# Flatpak application command wrapper for org.keepassxc.KeePassXC 
+#
+# This scripts is an application specific workaround to the limitation of one
+# command per Flatpak. It allows the Flatpak app to redirect input from
+# the KeePassXC-Browser extension to the `keepassxc-proxy` program.
+
+# Respect user settings "UseCustomProxy=true/false", whether it works or not
+if [[ -S "/run/user/$UID/app/org.keepassxc.KeePassXC/kpxc_server" ]]; then
+  if [[ "$1" =~ 'chrome-extension://' ]]; then
+    keepassxc-proxy "$@"
+  elif [[ "$1" =~ '.mozilla/native-messaging-hosts/org.keepassxc.keepassxc_browser.json' ]]; then
+    keepassxc-proxy "$@"
+  else
+    keepassxc "$@"
+  fi
+else
+  keepassxc "$@"
+fi

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -2,7 +2,7 @@ id: org.keepassxc.KeePassXC
 runtime: org.kde.Platform
 runtime-version: 5.10
 sdk: org.kde.Sdk
-command: keepassxc
+command: command-wrapper.sh
 rename-icon: keepassxc
 finish-args:
     # X11 + XShm access
@@ -26,8 +26,13 @@ finish-args:
   - --share=network
     # YubiKey USB access
   - --device=all
-    # Access to temporary files (should use xdg-run)
+    # Access to temporary files (should use xdg-run, similar to patch 0003)
   - --filesystem=/tmp
+    # KeePassXC-Browser (NativeMessagingHosts subdir does not exist by default)
+  - --filesystem=xdg-config/google-chrome
+  - --filesystem=xdg-config/chromium
+  - --filesystem=~/.mozilla
+  - --filesystem=xdg-config/vivaldi
 build-options:
   cflags: -O2 -g
   env: { V: '1' }
@@ -49,17 +54,25 @@ modules:
       - type: archive
         url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.3.3/keepassxc-2.3.3-src.tar.xz'
         sha256: cfff85ef89ba590aec798c59bea4aa3db00626d7bff8cdde0f62ee34aea60ad5
+      - type: file
+        path: command-wrapper.sh
       - type: patch
         path: patch/keepassxc/0001-Rename-indicator-icons-to-match-id.patch
       - type: patch
         path: patch/keepassxc/0002-Add-flatpak-distribution-type.patch
+      - type: patch
+        path: patch/keepassxc/0003-Use-dedicated-app-directory-for-runtime-data.patch
+      - type: patch
+        path: patch/keepassxc/0004-Fix-KeePassXC-Browser-interaction-with-Flatpak.patch
     post-install:
+      - install -Dm755 -t /app/bin command-wrapper.sh
       - |
         for f in COPYING LICENSE*; do
           install -Dm644 $f /app/share/licenses/org.keepassxc.KeePassXC/$f
         done
     cleanup:
       - /share/man
+
     modules:
 
       - name: libusb

--- a/patch/keepassxc/0003-Use-dedicated-app-directory-for-runtime-data.patch
+++ b/patch/keepassxc/0003-Use-dedicated-app-directory-for-runtime-data.patch
@@ -1,0 +1,40 @@
+From 3758f615165b044113f4a15772071c6ff2d7fd33 Mon Sep 17 00:00:00 2001
+From: AsavarTzeth <asavartzeth@gmail.com>
+Date: Mon, 28 May 2018 20:47:31 +0200
+Subject: [PATCH 3/3] Use dedicated app directory for runtime data
+
+There are issues with using XDG_RUNTIME_DIR directly. It has the
+potential of file name conflicts and it is harder to make specific
+sandbox exemptions, without including everything else in the same
+directory.
+
+Traditionally an application specific directory, in this case named
+"keepassxc" might have been used. This would make it possible to grant
+host access with `--filesystem=xdg-run/keepassxc`, see the man page
+flatpak-run (1).
+
+A better solution is to use `XDG_RUNTIME_DIR/app/APPID` where APPID
+in this case is "org.keepassxc.KeePassXC". This space is shared by the
+host and flatpak sandbox by default and the use of the reverse dns id
+helps prevent file conflicts.
+---
+ src/browser/NativeMessagingBase.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/browser/NativeMessagingBase.cpp b/src/browser/NativeMessagingBase.cpp
+index 743953e9..516f6e96 100644
+--- a/src/browser/NativeMessagingBase.cpp
++++ b/src/browser/NativeMessagingBase.cpp
+@@ -133,7 +133,8 @@ QString NativeMessagingBase::getLocalServerPath() const
+     return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/kpxc_server";
+ #elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+     // Use XDG_RUNTIME_DIR instead of /tmp/ if it's available
+-    QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/kpxc_server";
++    // TODO should ensure XDG_RUNTIME_DIR/app/APPID exists (in case Flatpak is not used)
++    QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + "/app/org.keepassxc.KeePassXC/kpxc_server";
+     return path.isEmpty() ? "/tmp/kpxc_server" : path;
+ #else   // Q_OS_MAC and others
+     return "/tmp/kpxc_server";
+-- 
+2.17.0
+

--- a/patch/keepassxc/0004-Fix-KeePassXC-Browser-interaction-with-Flatpak.patch
+++ b/patch/keepassxc/0004-Fix-KeePassXC-Browser-interaction-with-Flatpak.patch
@@ -1,0 +1,48 @@
+From ebba8e616b82918c817a9edee35433cb9cf009a5 Mon Sep 17 00:00:00 2001
+From: AsavarTzeth <asavartzeth@gmail.com>
+Date: Mon, 28 May 2018 21:29:15 +0200
+Subject: [PATCH 4/4] Fix KeePassXC-Browser interaction with Flatpak
+
+By default KeePassXC will use the `keepassxc-proxy` program as a proxy
+between `keepassxc` and a browser. The problem is that KeePassXC
+assumes the absolute path of this proxy is reachable by the browser.
+
+In the case of Flatpak, KeePassXC thinks this path is:
+"/app/bin/keepassxc-proxy"
+
+In a Flatpak all app files are installed in the `/app` prefix. At
+runtime this is mounted inside a container and otherwise unavailable.
+Because the Native Messaging API demands an absolute path, without any
+parameters, `flatpak run --command=keepassxc-proxy` cannot be used.
+
+Luckily Flatpak exports a wrapper script for all apps installed. In the
+default system-wide installation this would be located at:
+"/var/lib/flatpak/exports/bin/org.keepassxc.KeePassXC".
+
+If a user has installed the Flatpak elsewhere, like in a user specific
+installation (--user), it is still possible to enter a custom proxy
+path. It is then assumed the user knows where the wrapper is located.
+---
+ src/browser/HostInstaller.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/browser/HostInstaller.cpp b/src/browser/HostInstaller.cpp
+index 9b27ab1c..66e911f9 100644
+--- a/src/browser/HostInstaller.cpp
++++ b/src/browser/HostInstaller.cpp
+@@ -169,6 +169,12 @@ QJsonObject HostInstaller::constructFile(SupportedBrowsers browser, const bool&
+     } else {
+         path = QProcessEnvironment::systemEnvironment().value("APPIMAGE");
+     }
++#elif defined KEEPASSXC_DIST_FLATPAK
++    if (proxy && !location.isEmpty()) {
++        path = location;
++    } else {
++        path = "/var/lib/flatpak/exports/bin/org.keepassxc.KeePassXC";
++    }
+ #else
+     if (proxy) {
+         if (!location.isEmpty()) {
+-- 
+2.17.1
+


### PR DESCRIPTION
The KeePassXC-Browser extension did not work with Flatpak. The reasons
for this are many and there is no perfect solution. Still this should
fix it for most users. In cases where it does not, it is fixable with
minor configuration.

There are some limitations and pre-requisites for this to work:

1. Supported browsers (Chromium, Google Chrome, Firefox, Vivaldi) cannot
   sandbox their respective configuration directories. Host access must
   be possible.

2. This works by default, assuming the default system-wide installation
   is used. Specifically "/var/lib/flatpak/exports/bin" must contain
   "org.keepassxc.KeePassXC". If this is not the case users can override
   this by setting a custom proxy path within KeePassXC.