### PR TITLE
keepassxc: Update to 2.4.1

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -33,6 +33,7 @@ finish-args:
   - --filesystem=~/.mozilla/native-messaging-hosts:create
   - --filesystem=xdg-config/vivaldi/NativeMessagingHosts:create
   - --filesystem=~/.tor-browser/app/Browser/TorBrowser/Data/Browser/.mozilla/native-messaging-hosts:create
+  - --filesystem=xdg-config/BraveSoftware/Brave-Browser/NativeMessagingHosts:create
     # SSH Agent access
   - --socket=ssh-auth
     # Host access: workaround extensive portal issues

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -56,8 +56,8 @@ modules:
       - -DCMAKE_INSTALL_LIBDIR=lib
     sources:
       - type: archive
-        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.4.0/keepassxc-2.4.0-src.tar.xz'
-        sha256: 081ff1a34da8e0e8db951b5d70824d7a2b3d299ed4ae54e6ddc1e3ac176b95a8
+        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.4.1/keepassxc-2.4.1-src.tar.xz'
+        sha256: 0da97bd1279d1b9b06a63b9f723b43ab8c078b7f1203d6c13504fdd4735489ab
       - type: file
         path: command-wrapper.sh
       - type: patch

--- a/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
+++ b/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
@@ -1,4 +1,4 @@
-From b84e2122d1f582b85a0553b9fdc9e7f13be700c0 Mon Sep 17 00:00:00 2001
+From da11533f66c1724a9b295c0e707d0645051dbd1f Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Thu, 1 Mar 2018 10:33:22 +0100
 Subject: [PATCH 1/4] Add flatpak distribution type
@@ -17,7 +17,7 @@ gui, so that bug reports correctly reflect this.
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 658548f7..6ecab441 100644
+index 16d574f0..13624462 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -17,6 +17,7 @@
@@ -28,7 +28,7 @@ index 658548f7..6ecab441 100644
  
  if(NOT CMAKE_BUILD_TYPE)
      set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
-@@ -138,11 +139,13 @@ message(STATUS "Setting up build for KeePassXC v${KEEPASSXC_VERSION}\n")
+@@ -149,11 +150,13 @@ message(STATUS "Setting up build for KeePassXC v${KEEPASSXC_VERSION}\n")
  # Distribution info
  set(KEEPASSXC_DIST ON)
  set(KEEPASSXC_DIST_TYPE "Other" CACHE STRING "KeePassXC Distribution Type")
@@ -44,10 +44,10 @@ index 658548f7..6ecab441 100644
      unset(KEEPASSXC_DIST)
  endif()
 diff --git a/src/config-keepassx.h.cmake b/src/config-keepassx.h.cmake
-index 7d701886..9b9f030d 100644
+index 2acff446..134b948b 100644
 --- a/src/config-keepassx.h.cmake
 +++ b/src/config-keepassx.h.cmake
-@@ -31,6 +31,7 @@
+@@ -32,6 +32,7 @@
  #cmakedefine KEEPASSXC_DIST_TYPE "@KEEPASSXC_DIST_TYPE@"
  #cmakedefine KEEPASSXC_DIST_SNAP
  #cmakedefine KEEPASSXC_DIST_APPIMAGE

--- a/patch/keepassxc/0002-Use-reverse-dns-for-flatpak-exportable-files.patch
+++ b/patch/keepassxc/0002-Use-reverse-dns-for-flatpak-exportable-files.patch
@@ -1,4 +1,4 @@
-From 7215fdb15125827a3d2f84d6a29b298f39438eef Mon Sep 17 00:00:00 2001
+From 1d3858bff8ad1871c63ef20671342c3a2ef62a4c Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Mon, 18 Mar 2019 19:17:41 +0100
 Subject: [PATCH 2/4] Use reverse-dns for flatpak exportable files
@@ -20,13 +20,13 @@ the system. Otherwise it would only be available inside the sandbox.
  rename share/linux/{org.keepassxc.KeePassXC.desktop => org.keepassxc.KeePassXC.desktop.in} (96%)
 
 diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
-index 214c0ec9..4359e440 100644
+index 635ee596..98163a5c 100644
 --- a/share/CMakeLists.txt
 +++ b/share/CMakeLists.txt
 @@ -24,15 +24,47 @@ file(GLOB DATABASE_ICONS icons/database/*.png)
  install(FILES ${DATABASE_ICONS} DESTINATION ${DATA_INSTALL_DIR}/icons/database)
  
- if(UNIX AND NOT APPLE)
+ if(UNIX AND NOT APPLE AND NOT HAIKU)
 -    install(DIRECTORY icons/application/ DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor
 -            FILES_MATCHING PATTERN "keepassx*.png" PATTERN "keepassx*.svg"
 -            PATTERN "status" EXCLUDE PATTERN "actions" EXCLUDE PATTERN "categories" EXCLUDE)
@@ -77,7 +77,7 @@ index 214c0ec9..4359e440 100644
 +    configure_file(linux/${ID}.desktop.in linux/${ID}.desktop @ONLY)
 +    install(FILES linux/${ID}.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
 +    install(FILES linux/${ID}.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
- endif(UNIX AND NOT APPLE)
+ endif(UNIX AND NOT APPLE AND NOT HAIKU)
  
  if(APPLE)
 diff --git a/share/linux/.gitignore b/share/linux/.gitignore

--- a/patch/keepassxc/0003-Fix-KeePassXC-Browser-interaction-with-Flatpak.patch
+++ b/patch/keepassxc/0003-Fix-KeePassXC-Browser-interaction-with-Flatpak.patch
@@ -1,4 +1,4 @@
-From 24a5d56df096cd86b3b89c34b4717572c29cbeb5 Mon Sep 17 00:00:00 2001
+From da230248cc0766e968f023bb7ae1b0283067ce7c Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Mon, 28 May 2018 21:29:15 +0200
 Subject: [PATCH 3/4] Fix KeePassXC-Browser interaction with Flatpak
@@ -34,7 +34,7 @@ Hopefully in the future the Native Messaging Host API will support D-Bus.
  3 files changed, 27 insertions(+), 2 deletions(-)
 
 diff --git a/src/browser/BrowserOptionDialog.cpp b/src/browser/BrowserOptionDialog.cpp
-index dd91f159..292c68a7 100644
+index 9eecc63f..5ca678d6 100644
 --- a/src/browser/BrowserOptionDialog.cpp
 +++ b/src/browser/BrowserOptionDialog.cpp
 @@ -52,6 +52,7 @@ BrowserOptionDialog::BrowserOptionDialog(QWidget* parent)
@@ -67,8 +67,8 @@ index dd91f159..292c68a7 100644
 +#endif
  
  #ifdef Q_OS_WIN
-     // Vivaldi uses Chrome's registry settings
-@@ -144,8 +149,17 @@ void BrowserOptionDialog::loadSettings()
+     // Brave uses Chrome's registry settings
+@@ -147,8 +152,17 @@ void BrowserOptionDialog::loadSettings()
                                                    MessageWidget::Warning);
      m_ui->browserGlobalWarningWidget->setCloseButtonVisible(false);
      m_ui->browserGlobalWarningWidget->setAutoHideTimeout(-1);
@@ -86,7 +86,7 @@ index dd91f159..292c68a7 100644
      // Check for native messaging host location errors
      QString path;
      if (!settings->checkIfProxyExists(path)) {
-@@ -156,6 +170,7 @@ void BrowserOptionDialog::loadSettings()
+@@ -159,6 +173,7 @@ void BrowserOptionDialog::loadSettings()
      } else {
          m_ui->scriptWarningWidget->setVisible(false);
      }
@@ -95,10 +95,10 @@ index dd91f159..292c68a7 100644
  
  void BrowserOptionDialog::saveSettings()
 diff --git a/src/browser/HostInstaller.cpp b/src/browser/HostInstaller.cpp
-index 08782fa1..aa81967e 100644
+index 20c55456..1f30b217 100644
 --- a/src/browser/HostInstaller.cpp
 +++ b/src/browser/HostInstaller.cpp
-@@ -249,12 +249,18 @@ QString HostInstaller::getInstallDir(SupportedBrowsers browser) const
+@@ -257,12 +257,18 @@ QString HostInstaller::getInstallDir(SupportedBrowsers browser) const
  QString HostInstaller::getProxyPath(const bool& proxy, const QString& location) const
  {
      QString path;

--- a/patch/keepassxc/0004-Use-RuntimeDirectory-for-opening-attachments.patch
+++ b/patch/keepassxc/0004-Use-RuntimeDirectory-for-opening-attachments.patch
@@ -1,4 +1,4 @@
-From 1b58e2954a2bf1ae7389e9749b58e9e228f75026 Mon Sep 17 00:00:00 2001
+From 1635d0c66f03ff109df2119abe43997e731dba26 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Fri, 22 Mar 2019 17:02:22 +0100
 Subject: [PATCH 4/4] Use RuntimeDirectory for opening attachments


### PR DESCRIPTION
Upstream version 2.4.1 release: https://github.com/keepassxreboot/keepassxc/releases/tag/2.4.1

This is untested since I've no idea how to build yet to test flatpaks, but based on KeepassXC
release notes there are just minor changes and bug fixes in this release.

Fixes #35 