### PR TITLE
Use keepassxc-wrapper in desktop entry file

### DIFF
--- a/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
+++ b/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
@@ -1,4 +1,4 @@
-From 39d8b734a3601e567e572338fe8945fa2c70a92f Mon Sep 17 00:00:00 2001
+From c60833f851f00708e3e42582c2e8020b3119a2c8 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Mon, 28 May 2018 21:29:15 +0200
 Subject: [PATCH 3/5] Flatpak: Support KeePassXC-Browser integration
@@ -36,14 +36,61 @@ Limitations and caveats
 Note: The Native Messaging Host API would be a lot more sandbox friendly
 with the addition of D-Bus support, as an alternative to stdio.
 ---
- src/browser/BrowserSettingsWidget.cpp  | 12 ++++++++
- src/browser/BrowserShared.cpp          |  3 ++
- src/browser/NativeMessageInstaller.cpp | 36 ++++++++++++++++++++++-
- src/browser/NativeMessageInstaller.h   |  2 ++
- utils/flatpak-command-wrapper.sh       | 40 ++++++++++++++++++++++++++
- 5 files changed, 92 insertions(+), 1 deletion(-)
+ share/CMakeLists.txt                          |  7 +++-
+ .../linux/org.keepassxc.KeePassXC.desktop.in  |  4 +-
+ src/browser/BrowserSettingsWidget.cpp         | 12 ++++++
+ src/browser/BrowserShared.cpp                 |  3 ++
+ src/browser/NativeMessageInstaller.cpp        | 36 ++++++++++++++++-
+ src/browser/NativeMessageInstaller.h          |  2 +
+ utils/flatpak-command-wrapper.sh              | 40 +++++++++++++++++++
+ 7 files changed, 100 insertions(+), 4 deletions(-)
  create mode 100755 utils/flatpak-command-wrapper.sh
 
+diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
+index 43bcbb39..e80794b6 100644
+--- a/share/CMakeLists.txt
++++ b/share/CMakeLists.txt
+@@ -23,10 +23,13 @@ install(FILES ${wordlists_files} DESTINATION ${DATA_INSTALL_DIR}/wordlists)
+ file(COPY "wordlists" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ 
+ if(UNIX AND NOT APPLE AND NOT HAIKU)
+-    # Flatpak requires all host accessible files to use filenames based upon the app id
+     if(KEEPASSXC_DIST_FLATPAK)
++        # Use keepassxc-wrapper as workaround to run keepassxc-proxy when needed
++        set(APP_EXEC "keepassxc-wrapper")
++        # All files exported to the host must be prefixed with the reverse dns app id
+         set(APP_ICON "${ID}")
+         set(MIME_ICON "${ID}.application-x-keepassxc")
++
+         configure_file(linux/keepassxc.xml.in linux/${ID}.xml @ONLY)
+         install(FILES linux/${ID}.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
+ 
+@@ -46,8 +49,10 @@ if(UNIX AND NOT APPLE AND NOT HAIKU)
+                     RENAME ${icon_name})
+         endforeach()
+     else()
++        set(APP_EXEC "keepassxc")
+         set(APP_ICON "keepassxc")
+         set(MIME_ICON "application-x-keepassxc")
++
+         configure_file(linux/keepassxc.xml.in keepassxc.xml @ONLY)
+         install(FILES linux/keepassxc.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
+ 
+diff --git a/share/linux/org.keepassxc.KeePassXC.desktop.in b/share/linux/org.keepassxc.KeePassXC.desktop.in
+index ae74f43f..5adf7e18 100644
+--- a/share/linux/org.keepassxc.KeePassXC.desktop.in
++++ b/share/linux/org.keepassxc.KeePassXC.desktop.in
+@@ -8,8 +8,8 @@ GenericName[fr]=Gestionnaire de mot de passe
+ GenericName[ru]=менеджер паролей
+ Comment=Community-driven port of the Windows application “KeePass Password Safe”
+ Comment[da]=Fællesskabsdrevet port af Windows-programmet “KeePass Password Safe”
+-Exec=keepassxc %f
+-TryExec=keepassxc
++Exec=@APP_EXEC@ %f
++TryExec=@APP_EXEC@
+ Icon=@APP_ICON@
+ StartupWMClass=keepassxc
+ StartupNotify=true
 diff --git a/src/browser/BrowserSettingsWidget.cpp b/src/browser/BrowserSettingsWidget.cpp
 index d0bdad1f..9d6eed06 100644
 --- a/src/browser/BrowserSettingsWidget.cpp

--- a/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
+++ b/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
@@ -1,4 +1,4 @@
-From 8c2f231a56b61d518af72a8650dc11021ce78f58 Mon Sep 17 00:00:00 2001
+From a2f05d2f8b97636457ed17a1e1c39e30edcfef5b Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Fri, 22 Mar 2019 17:02:22 +0100
 Subject: [PATCH 4/5] Flatpak: Support sandboxed attachment opening

--- a/patch/keepassxc/0005-Add-OARS-metadata.patch
+++ b/patch/keepassxc/0005-Add-OARS-metadata.patch
@@ -1,4 +1,4 @@
-From bc40c533eb8585cf4ee224ef7cdbdccbef1aa425 Mon Sep 17 00:00:00 2001
+From 8029e60551649ac01ff7fbbc2b7f72263da500f6 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Mon, 1 Jul 2019 17:27:58 +0200
 Subject: [PATCH 5/5] Add OARS metadata


### PR DESCRIPTION
By setting keepassxc-wrapper as the command in the manifest file
browsers are able to communicate with keepassxc-proxy. However this
does not affect DBus activation or the desktop entry file, which will
use keepassxc directly.

For the browser integration this does not matter; it works regardless.
But this does confuse things when the namespaced pid is changes between
2 & 3. Suddenly indicator support requires ownership of either:
org.kde.StatusNotifierItem-2-2 or org.kde.StatusNotifierItem-3-2

By making the behaviour consistent it is less confusing and hopefully
this removes the need to also allow:
`--own-name=org.kde.StatusNotifierItem-2-2`
which most likely is even more prone to conflicts.

Fixes #58