### PR TITLE
Force xorg/Xwayland and Qt QPA issues

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=x11
     # Wayland access
   - --socket=wayland
+  - --env=QT_QPA_PLATFORM=xcb
     # Notification access
   - --talk-name=org.freedesktop.Notifications
     # Screen Lock Listener


### PR DESCRIPTION
There appears are multiple issues with qt qpa platform detection with
many different issues as a result.

Some known issues:
- Sporadically broken clipboard support
- Invalid detection of wayland during x-session resulting in inability
  to launch the app.
- Some xdg-desktop-portal file chooser crashes that seem to be caused
  by some attempt to contact x, even in a wayland session?

At best, this is a "magic" workaround for some of these issues and
at worst doesn't seem to harm anything other than those that want
out-of-the-box native wayland (me).

At this point it seems better to let those user's set
QT_QPA_PLATFORM=wayland or QT_QPA_PLATFORM=wayland-egl as overrides.

Testing didn't reveal any regression with copying username/password
between KeePassXC (Xwayland) to other wayland apps, as opposed
to previously KeePassXC (Wayland) to wayland.