### PR TITLE
Update keepassxc to 2.6.4

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -21,7 +21,8 @@ finish-args:
   - --talk-name=com.canonical.Unity.Session
     # System Tray Icon (Test at every major update)
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.StatusNotifierItem-2-2 # Especially test these
+  - --own-name=org.kde.StatusNotifierItem-2-1 # Especially test these
+  - --own-name=org.kde.StatusNotifierItem-2-2
   - --own-name=org.kde.StatusNotifierItem-3-2
     # Favicon Download
   - --share=network
@@ -65,8 +66,8 @@ modules:
       - -DWITH_XC_FDOSECRETS=OFF
     sources:
       - type: archive
-        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.6.3/keepassxc-2.6.3-src.tar.xz'
-        sha256: e7e0b6ed8f3881c5b9579074bc3cde3991b28c1a3d1c852c46f2b7930a10f7d1
+        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.6.4/keepassxc-2.6.4-src.tar.xz'
+        sha256: e536e2a71c90fcf264eb831fb1a8b518ee1b03829828f862eeea748d3310f82b
       - type: patch
         path: patch/keepassxc/0001-Add-flatpak-distribution-type.patch
       - type: patch

--- a/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
+++ b/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
@@ -1,4 +1,4 @@
-From de147c5c996eab1d142b1a69889a7d66b0fe50c3 Mon Sep 17 00:00:00 2001
+From f0f9e8e9a35e88de3f91c48a40350a114f3cdc33 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 14:31:05 +0200
 Subject: [PATCH 1/4] Add flatpak distribution type
@@ -13,7 +13,7 @@ is properly displayed as the distribution type in the app debug tab.
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d390f672..a1d17d77 100644
+index 55cecbe7..d15ca281 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -17,6 +17,7 @@
@@ -52,5 +52,5 @@ index 6aceaa2a..9cc7426b 100644
  #cmakedefine HAVE_PR_SET_DUMPABLE 1
  #cmakedefine HAVE_RLIMIT_CORE 1
 -- 
-2.28.0
+2.30.0
 

--- a/patch/keepassxc/0002-Support-reverse-dns-filenames-for-data-files.patch
+++ b/patch/keepassxc/0002-Support-reverse-dns-filenames-for-data-files.patch
@@ -1,4 +1,4 @@
-From c39a2cc67d6c9850a3418849b4c55602417b901b Mon Sep 17 00:00:00 2001
+From 49ae7785675b079f7908b1ce447585ec2a93771a Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 14:54:18 +0200
 Subject: [PATCH 2/4] Support reverse-dns filenames for data files
@@ -15,14 +15,14 @@ exportable filenames, without affecting other distribution types.
  share/linux/.gitignore                        |  3 ++
  .../linux/{keepassxc.xml => keepassxc.xml.in} |  2 +-
  ...top => org.keepassxc.KeePassXC.desktop.in} |  2 +-
- src/core/Resources.cpp                        | 24 ++++++++++
- 5 files changed, 67 insertions(+), 11 deletions(-)
+ src/core/Resources.cpp                        | 10 ++++
+ 5 files changed, 53 insertions(+), 11 deletions(-)
  create mode 100644 share/linux/.gitignore
  rename share/linux/{keepassxc.xml => keepassxc.xml.in} (85%)
  rename share/linux/{org.keepassxc.KeePassXC.desktop => org.keepassxc.KeePassXC.desktop.in} (99%)
 
 diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
-index 6d689df9..43bcbb39 100644
+index 6d689df9..b069e4a4 100644
 --- a/share/CMakeLists.txt
 +++ b/share/CMakeLists.txt
 @@ -23,15 +23,44 @@ install(FILES ${wordlists_files} DESTINATION ${DATA_INSTALL_DIR}/wordlists)
@@ -41,7 +41,7 @@ index 6d689df9..43bcbb39 100644
 +    # Flatpak requires all host accessible files to use filenames based upon the app id
 +    if(KEEPASSXC_DIST_FLATPAK)
 +        set(APP_ICON "${ID}")
-+        set(MIME_ICON "${ID}.application-x-keepassxc")
++        set(MIME_ICON "${ID}-application-x-keepassxc")
 +        configure_file(linux/keepassxc.xml.in linux/${ID}.xml @ONLY)
 +        install(FILES linux/${ID}.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
 +
@@ -53,8 +53,8 @@ index 6d689df9..43bcbb39 100644
 +            get_filename_component(icon_dir ${icon_match} DIRECTORY)
 +            # Prefix all icons with application id: "org.keepassxc.KeePassXC"
 +            string(REGEX REPLACE "^keepassxc(.*)?(\\.png|\\.svg)$" "${ID}\\1\\2" icon_name ${icon_name})
-+            string(REGEX REPLACE "^(application-x-keepassxc\\.svg)$" "${ID}.\\1" icon_name ${icon_name})
-+            string(REGEX REPLACE "^(${ID})-(.*)$" "\\1.\\2" icon_name ${icon_name})
++            string(REGEX REPLACE "^(application-x-keepassxc\\.svg)$" "${ID}-\\1" icon_name ${icon_name})
++	    #string(REGEX REPLACE "^(${ID})-(.*)$" "\\1.\\2" icon_name ${icon_name})
 +            # Find icon sub dir ex. "scalable/mimetypes/"
 +            file(RELATIVE_PATH icon_subdir ${CMAKE_CURRENT_SOURCE_DIR}/icons/application ${icon_dir})
 +            install(FILES ${icon_match} DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/${icon_subdir}
@@ -120,10 +120,10 @@ index 693232e9..7774c1ac 100644
  StartupNotify=true
  Terminal=false
 diff --git a/src/core/Resources.cpp b/src/core/Resources.cpp
-index ae8c0d46..cd92dfe7 100644
+index df89a4f9..b5708462 100644
 --- a/src/core/Resources.cpp
 +++ b/src/core/Resources.cpp
-@@ -98,7 +98,11 @@ QString Resources::wordlistPath(const QString& name) const
+@@ -111,7 +111,11 @@ QString Resources::wordlistPath(const QString& name) const
  
  QIcon Resources::applicationIcon()
  {
@@ -135,52 +135,27 @@ index ae8c0d46..cd92dfe7 100644
  }
  
  QString Resources::trayIconAppearance() const
-@@ -124,12 +128,22 @@ QIcon Resources::trayIconLocked()
+@@ -138,7 +142,11 @@ QIcon Resources::trayIcon(QString style)
+ 
      auto iconApperance = trayIconAppearance();
- 
-     if (iconApperance == "monochrome-light") {
+     if (!iconApperance.startsWith("monochrome")) {
 +#ifdef KEEPASSXC_DIST_FLATPAK
-+        return icon("org.keepassxc.KeePassXC.monochrome-light-locked", false);
++        return icon(QString("org.keepassxc.KeePassXC%1").arg(style), false);
 +#else
-         return icon("keepassxc-monochrome-light-locked", false);
+         return icon(QString("keepassxc%1").arg(style), false);
 +#endif
      }
-     if (iconApperance == "monochrome-dark") {
-+#ifdef KEEPASSXC_DIST_FLATPAK
-+        return icon("org.keepassxc.KeePassXC.monochrome-dark-locked", false);
-+    }
-+    return icon("org.keepassxc.KeePassXC.locked", false);
-+#else
-         return icon("keepassxc-monochrome-dark-locked", false);
-     }
-     return icon("keepassxc-locked", false);
-+#endif
- }
  
- QIcon Resources::trayIconUnlocked()
-@@ -137,12 +151,22 @@ QIcon Resources::trayIconUnlocked()
-     auto iconApperance = trayIconAppearance();
- 
-     if (iconApperance == "monochrome-light") {
-+#ifdef KEEPASSXC_DIST_FLATPAK
-+        return icon("org.keepassxc.KeePassXC.monochrome-light", false);
-+#else
-         return icon("keepassxc-monochrome-light", false);
-+#endif
+     QIcon i;
+@@ -148,6 +156,8 @@ QIcon Resources::trayIcon(QString style)
+     } else {
+         i = icon(QString("keepassxc-monochrome-dark%1").arg(style), false);
      }
-     if (iconApperance == "monochrome-dark") {
-+#ifdef KEEPASSXC_DIST_FLATPAK
-+        return icon("org.keepassxc.KeePassXC.monochrome-dark", false);
-+    }
-+    return icon("org.keepassxc.KeePassXC", false);
-+#else
-         return icon("keepassxc-monochrome-dark", false);
-     }
-     return icon("keepassxc", false);
-+#endif
- }
- 
- QIcon Resources::icon(const QString& name, bool recolor, const QColor& overrideColor)
++#elif defined(KEEPASSXC_DIST_FLATPAK)
++    i = icon(QString("org.keepassxc.KeePassXC-%1%2").arg(iconApperance, style), false);
+ #else
+     i = icon(QString("keepassxc-%1%2").arg(iconApperance, style), false);
+ #endif
 -- 
-2.28.0
+2.30.0
 

--- a/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
+++ b/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
@@ -1,4 +1,4 @@
-From a1e06e4c447fa8b9883c599e73f506aee2d53253 Mon Sep 17 00:00:00 2001
+From 6070fc75c6f7a17dfc53831cbc638f4c56b3e8a4 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 17:07:12 +0200
 Subject: [PATCH 3/4] Flatpak: Support KeePassXC-Browser integration
@@ -68,7 +68,7 @@ index d0bdad1f..9d6eed06 100644
      const auto customBrowserSet = settings->customBrowserSupport();
      m_ui->customBrowserSupport->setChecked(customBrowserSet);
 diff --git a/src/browser/BrowserShared.cpp b/src/browser/BrowserShared.cpp
-index 08b9fe53..87e7e689 100644
+index 69d0db49..52101b1a 100644
 --- a/src/browser/BrowserShared.cpp
 +++ b/src/browser/BrowserShared.cpp
 @@ -30,6 +30,9 @@ namespace BrowserShared
@@ -201,5 +201,5 @@ index 00000000..5b6ff8e2
 +# If no arguments are matched or browser integration is off execute keepassxc
 +exec keepassxc "$@"
 -- 
-2.28.0
+2.30.0
 

--- a/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
+++ b/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
@@ -1,4 +1,4 @@
-From 1585dd76124b461d1eed909362afd12c92bb68d7 Mon Sep 17 00:00:00 2001
+From 3e8137d54a7ffdb108faa2112a6d8a8a5a08ae86 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 17:07:20 +0200
 Subject: [PATCH 4/4] Flatpak: Support sandboxed attachment opening
@@ -44,5 +44,5 @@ index 836c8ef2..f2740903 100644
      const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXX.").append(filename));
  #endif
 -- 
-2.28.0
+2.30.0
 


### PR DESCRIPTION
Main app works as usual.

Icons and mime types export correctly, (especially) indicator/tray
icons require testing. My tests were inconclusive, due to broken gnome
extensions.