### PR TITLE
upgrade runtime to 5.15-21.08

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -1,6 +1,6 @@
 id: org.keepassxc.KeePassXC
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: keepassxc-wrapper
 finish-args:


### PR DESCRIPTION
This PR upgrades KDE runtime to version built from org.freedesktop.Platform 21.08 rather than 20.08 used by 5.15. Thanks!