### PR TITLE
Update to 2.7.0

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -29,7 +29,7 @@ finish-args:
     # YubiKey USB access
   - --device=all
     # Access to temporary files (Remove if RuntimeDirectory patch is upstreamed)
-  - --filesystem=/tmp
+  # - --filesystem=/tmp
     # SSH Agent access
   - --socket=ssh-auth
     # Host access: workaround extensive portal issues
@@ -66,8 +66,8 @@ modules:
       - -DWITH_XC_FDOSECRETS=OFF
     sources:
       - type: archive
-        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.6.6/keepassxc-2.6.6-src.tar.xz'
-        sha256: 3603b11ac39b289c47fac77fa150e05fd64b393d8cfdf5732dc3ef106650a4e2
+        url: 'https://github.com/keepassxreboot/keepassxc/releases/download/2.7.0/keepassxc-2.7.0-src.tar.xz'
+        sha256: 83be76890904cd6703343fa097d68bcfdd99bb525cf518fa62a7df9293026aa7
       - type: patch
         path: patch/keepassxc/0001-Add-flatpak-distribution-type.patch
       - type: patch
@@ -179,8 +179,8 @@ modules:
         sources:
           - type: git
             url: 'https://github.com/stachenov/quazip.git'
-            tag: v1.1
-            commit: 100578f686b7da029a19c0bc9ad3c93f80adb2bb
+            tag: v1.2
+            commit: b6d1cecbe9f5ff760d4964e9fc77f1b06b75e045
         post-install:
           - install -Dm644 -t /app/share/licenses/libquazip COPYING
 
@@ -193,6 +193,6 @@ modules:
         sources:
           - type: file
             url: 'https://rubygems.org/downloads/asciidoctor-2.0.10.gem'
-            sha256: 7f3df92816f75344d36bb15e49a6fbc07ac0999a1cd2938fd0802ea587964aac
+            sha256: ed5b5e399e8d64994cc16f0983f993d6e33990909a8415b6fc8b786cdeb00f3d
         cleanup:
           - '*'

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -189,10 +189,10 @@ modules:
         build-commands:
           - gem install --ignore-dependencies --no-user-install --verbose --local
                         --install-dir /app/lib/ruby/gems/2.6.0 --bindir /app/bin
-                        asciidoctor-2.0.10.gem
+                        asciidoctor-2.0.17.gem
         sources:
           - type: file
-            url: 'https://rubygems.org/downloads/asciidoctor-2.0.10.gem'
+            url: 'https://rubygems.org/downloads/asciidoctor-2.0.17.gem'
             sha256: ed5b5e399e8d64994cc16f0983f993d6e33990909a8415b6fc8b786cdeb00f3d
         cleanup:
           - '*'

--- a/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
+++ b/patch/keepassxc/0001-Add-flatpak-distribution-type.patch
@@ -1,4 +1,4 @@
-From f0f9e8e9a35e88de3f91c48a40350a114f3cdc33 Mon Sep 17 00:00:00 2001
+From 4c8d026e91597117d94d8756effb2d4ca6b6a9f7 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 14:31:05 +0200
 Subject: [PATCH 1/4] Add flatpak distribution type
@@ -13,7 +13,7 @@ is properly displayed as the distribution type in the app debug tab.
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 55cecbe7..d15ca281 100644
+index baa399de..27932db1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -17,6 +17,7 @@
@@ -24,7 +24,7 @@ index 55cecbe7..d15ca281 100644
  
  if(NOT CMAKE_BUILD_TYPE)
      set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
-@@ -167,11 +168,13 @@ message(STATUS "Setting up build for KeePassXC v${KEEPASSXC_VERSION}\n")
+@@ -158,11 +159,13 @@ message(STATUS "Setting up build for KeePassXC v${KEEPASSXC_VERSION}\n")
  # Distribution info
  set(KEEPASSXC_DIST ON)
  set(KEEPASSXC_DIST_TYPE "Other" CACHE STRING "KeePassXC Distribution Type")
@@ -40,10 +40,10 @@ index 55cecbe7..d15ca281 100644
      unset(KEEPASSXC_DIST)
  endif()
 diff --git a/src/config-keepassx.h.cmake b/src/config-keepassx.h.cmake
-index 6aceaa2a..9cc7426b 100644
+index 6b855c62..6caa89d8 100644
 --- a/src/config-keepassx.h.cmake
 +++ b/src/config-keepassx.h.cmake
-@@ -33,6 +33,7 @@
+@@ -31,6 +31,7 @@
  #cmakedefine KEEPASSXC_DIST_TYPE "@KEEPASSXC_DIST_TYPE@"
  #cmakedefine KEEPASSXC_DIST_SNAP
  #cmakedefine KEEPASSXC_DIST_APPIMAGE
@@ -52,5 +52,5 @@ index 6aceaa2a..9cc7426b 100644
  #cmakedefine HAVE_PR_SET_DUMPABLE 1
  #cmakedefine HAVE_RLIMIT_CORE 1
 -- 
-2.30.0
+2.35.1
 

--- a/patch/keepassxc/0002-Support-reverse-dns-filenames-for-data-files.patch
+++ b/patch/keepassxc/0002-Support-reverse-dns-filenames-for-data-files.patch
@@ -1,4 +1,4 @@
-From 49ae7785675b079f7908b1ce447585ec2a93771a Mon Sep 17 00:00:00 2001
+From 19d1c1d9e998979d8402e4c2cf7910149bb6bf5c Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 14:54:18 +0200
 Subject: [PATCH 2/4] Support reverse-dns filenames for data files
@@ -15,7 +15,7 @@ exportable filenames, without affecting other distribution types.
  share/linux/.gitignore                        |  3 ++
  .../linux/{keepassxc.xml => keepassxc.xml.in} |  2 +-
  ...top => org.keepassxc.KeePassXC.desktop.in} |  2 +-
- src/core/Resources.cpp                        | 10 ++++
+ src/gui/Icons.cpp                             | 10 ++++
  5 files changed, 53 insertions(+), 11 deletions(-)
  create mode 100644 share/linux/.gitignore
  rename share/linux/{keepassxc.xml => keepassxc.xml.in} (85%)
@@ -107,11 +107,11 @@ diff --git a/share/linux/org.keepassxc.KeePassXC.desktop b/share/linux/org.keepa
 similarity index 99%
 rename from share/linux/org.keepassxc.KeePassXC.desktop
 rename to share/linux/org.keepassxc.KeePassXC.desktop.in
-index 693232e9..7774c1ac 100644
+index e8d4dccf..5b7779b4 100644
 --- a/share/linux/org.keepassxc.KeePassXC.desktop
 +++ b/share/linux/org.keepassxc.KeePassXC.desktop.in
-@@ -36,7 +36,7 @@ Comment[da]=Fællesskabsdrevet port af Windows-programmet “KeePass Password Sa
- Comment[et]=Kogukonna arendatav port Windowsi programmist KeePass Password Safe
+@@ -37,7 +37,7 @@ Comment[et]=Kogukonna arendatav port Windowsi programmist KeePass Password Safe
+ Comment[ru]=Разработанный сообществом порт Windows-приложения KeePass Password Safe
  Exec=keepassxc %f
  TryExec=keepassxc
 -Icon=keepassxc
@@ -119,13 +119,13 @@ index 693232e9..7774c1ac 100644
  StartupWMClass=keepassxc
  StartupNotify=true
  Terminal=false
-diff --git a/src/core/Resources.cpp b/src/core/Resources.cpp
-index df89a4f9..b5708462 100644
---- a/src/core/Resources.cpp
-+++ b/src/core/Resources.cpp
-@@ -111,7 +111,11 @@ QString Resources::wordlistPath(const QString& name) const
+diff --git a/src/gui/Icons.cpp b/src/gui/Icons.cpp
+index 0809e271..73da3487 100644
+--- a/src/gui/Icons.cpp
++++ b/src/gui/Icons.cpp
+@@ -54,7 +54,11 @@ Icons::Icons()
  
- QIcon Resources::applicationIcon()
+ QIcon Icons::applicationIcon()
  {
 +#ifdef KEEPASSXC_DIST_FLATPAK
 +    return icon("org.keepassxc.KeePassXC", false);
@@ -134,20 +134,20 @@ index df89a4f9..b5708462 100644
 +#endif
  }
  
- QString Resources::trayIconAppearance() const
-@@ -138,7 +142,11 @@ QIcon Resources::trayIcon(QString style)
+ QString Icons::trayIconAppearance() const
+@@ -81,7 +85,11 @@ QIcon Icons::trayIcon(QString style)
  
      auto iconApperance = trayIconAppearance();
      if (!iconApperance.startsWith("monochrome")) {
 +#ifdef KEEPASSXC_DIST_FLATPAK
-+        return icon(QString("org.keepassxc.KeePassXC%1").arg(style), false);
++	return icon(QString("org.keepassxc.KeePassXC%1").arg(style), false);
 +#else
          return icon(QString("keepassxc%1").arg(style), false);
 +#endif
      }
  
      QIcon i;
-@@ -148,6 +156,8 @@ QIcon Resources::trayIcon(QString style)
+@@ -91,6 +99,8 @@ QIcon Icons::trayIcon(QString style)
      } else {
          i = icon(QString("keepassxc-monochrome-dark%1").arg(style), false);
      }
@@ -157,5 +157,5 @@ index df89a4f9..b5708462 100644
      i = icon(QString("keepassxc-%1%2").arg(iconApperance, style), false);
  #endif
 -- 
-2.30.0
+2.35.1
 

--- a/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
+++ b/patch/keepassxc/0003-Flatpak-Support-KeePassXC-Browser-integration.patch
@@ -1,4 +1,4 @@
-From 6070fc75c6f7a17dfc53831cbc638f4c56b3e8a4 Mon Sep 17 00:00:00 2001
+From 9d80a4237dca0ca1e682468467639db78c466298 Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
 Date: Wed, 2 Sep 2020 17:07:12 +0200
 Subject: [PATCH 3/4] Flatpak: Support KeePassXC-Browser integration
@@ -45,10 +45,10 @@ with the addition of D-Bus support, as an alternative to stdio.
  create mode 100755 utils/flatpak-command-wrapper.sh
 
 diff --git a/src/browser/BrowserSettingsWidget.cpp b/src/browser/BrowserSettingsWidget.cpp
-index d0bdad1f..9d6eed06 100644
+index d0f81615..8dd26d32 100644
 --- a/src/browser/BrowserSettingsWidget.cpp
 +++ b/src/browser/BrowserSettingsWidget.cpp
-@@ -171,6 +171,18 @@ void BrowserSettingsWidget::loadSettings()
+@@ -158,6 +158,18 @@ void BrowserSettingsWidget::loadSettings()
      m_ui->browserGlobalWarningWidget->setCloseButtonVisible(false);
      m_ui->browserGlobalWarningWidget->setAutoHideTimeout(-1);
  #endif
@@ -68,10 +68,10 @@ index d0bdad1f..9d6eed06 100644
      const auto customBrowserSet = settings->customBrowserSupport();
      m_ui->customBrowserSupport->setChecked(customBrowserSet);
 diff --git a/src/browser/BrowserShared.cpp b/src/browser/BrowserShared.cpp
-index 69d0db49..52101b1a 100644
+index 22a50781..97a1228a 100644
 --- a/src/browser/BrowserShared.cpp
 +++ b/src/browser/BrowserShared.cpp
-@@ -30,6 +30,9 @@ namespace BrowserShared
+@@ -31,6 +31,9 @@ namespace BrowserShared
          const auto serverName = QStringLiteral("/org.keepassxc.KeePassXC.BrowserServer");
  #if defined(KEEPASSXC_DIST_SNAP)
          return QProcessEnvironment::systemEnvironment().value("SNAP_USER_COMMON") + serverName;
@@ -82,7 +82,7 @@ index 69d0db49..52101b1a 100644
          // Use XDG_RUNTIME_DIR instead of /tmp if it's available
          QString path = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
 diff --git a/src/browser/NativeMessageInstaller.cpp b/src/browser/NativeMessageInstaller.cpp
-index 8b038f61..16c4b9b0 100644
+index dbf6b9b3..1a183805 100644
 --- a/src/browser/NativeMessageInstaller.cpp
 +++ b/src/browser/NativeMessageInstaller.cpp
 @@ -30,6 +30,7 @@
@@ -142,10 +142,10 @@ index 8b038f61..16c4b9b0 100644
   * Constructs the JSON script file used with native messaging
   *
 diff --git a/src/browser/NativeMessageInstaller.h b/src/browser/NativeMessageInstaller.h
-index 4c0e339e..f605287a 100644
+index 256dd0c8..0823d6bc 100644
 --- a/src/browser/NativeMessageInstaller.h
 +++ b/src/browser/NativeMessageInstaller.h
-@@ -40,6 +40,8 @@ private:
+@@ -42,6 +42,8 @@ private:
      QJsonObject constructFile(BrowserShared::SupportedBrowsers browser);
      bool createNativeMessageFile(BrowserShared::SupportedBrowsers browser);
  
@@ -201,5 +201,5 @@ index 00000000..5b6ff8e2
 +# If no arguments are matched or browser integration is off execute keepassxc
 +exec keepassxc "$@"
 -- 
-2.30.0
+2.35.1
 

--- a/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
+++ b/patch/keepassxc/0004-Flatpak-Support-sandboxed-attachment-opening.patch
@@ -1,6 +1,6 @@
-From 3e8137d54a7ffdb108faa2112a6d8a8a5a08ae86 Mon Sep 17 00:00:00 2001
+From 43563b4321bdad77527c6fe3b0c44103cac3153d Mon Sep 17 00:00:00 2001
 From: AsavarTzeth <asavartzeth@gmail.com>
-Date: Wed, 2 Sep 2020 17:07:20 +0200
+Date: Sun, 27 Mar 2022 14:44:41 +0200
 Subject: [PATCH 4/4] Flatpak: Support sandboxed attachment opening
 
 Ensure that xdg portals can open attachment files, while simultaneously
@@ -13,36 +13,36 @@ it exists, respects XDG standards and is host accessible by default.
 - Respect $XDG_RUNTIME_DIR when available
 - Remove need for needlessly exposing the host /tmp
 ---
- src/gui/entry/EntryAttachmentsWidget.cpp | 8 +++++++-
- 1 file changed, 7 insertions(+), 1 deletion(-)
+ src/core/EntryAttachments.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
 
-diff --git a/src/gui/entry/EntryAttachmentsWidget.cpp b/src/gui/entry/EntryAttachmentsWidget.cpp
-index 836c8ef2..f2740903 100644
---- a/src/gui/entry/EntryAttachmentsWidget.cpp
-+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
-@@ -1,5 +1,6 @@
- #include "EntryAttachmentsWidget.h"
- #include "ui_EntryAttachmentsWidget.h"
+diff --git a/src/core/EntryAttachments.cpp b/src/core/EntryAttachments.cpp
+index eeeb6fb2..90a5ac57 100644
+--- a/src/core/EntryAttachments.cpp
++++ b/src/core/EntryAttachments.cpp
+@@ -17,6 +17,7 @@
+ 
+ #include "EntryAttachments.h"
+ 
 +#include "config-keepassx.h"
+ #include "core/Global.h"
+ #include "crypto/Random.h"
  
- #include <QDesktopServices>
- #include <QDir>
-@@ -333,9 +334,14 @@ bool EntryAttachmentsWidget::openAttachment(const QModelIndex& index, QString& e
-     const QByteArray attachmentData = m_entryAttachments->value(filename);
+@@ -218,9 +219,13 @@ bool EntryAttachments::openAttachment(const QString& key, QString* errorMessage)
+         const QByteArray attachmentData = value(key);
+         auto ext = key.contains(".") ? "." + key.split(".").last() : "";
  
-     // tmp file will be removed once the database (or the application) has been closed
 -#ifdef KEEPASSXC_DIST_SNAP
-+
 +#if defined(KEEPASSXC_DIST_SNAP)
-     const QString tmpFileTemplate =
-         QString("%1/XXXXXX.%2").arg(QProcessEnvironment::systemEnvironment().value("SNAP_USER_DATA"), filename);
+         const QString tmpFileTemplate =
+             QString("%1/XXXXXXXXXXXX%2").arg(QProcessEnvironment::systemEnvironment().value("SNAP_USER_DATA"), ext);
 +#elif defined(KEEPASSXC_DIST_FLATPAK)
-+    const QString tmpFileTemplate =
-+        QString("%1/app/%2/XXXXXX.%3").arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation),
-+                "org.keepassxc.KeePassXC", filename);
++        const QString tmpFileTemplate =
++            QString("%1/app/%2/XXXXXXXXXXXX%3").arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation),
++                "org.keepassxc.KeePassXC", ext);
  #else
-     const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXX.").append(filename));
+         const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXXXXXXXX").append(ext));
  #endif
 -- 
-2.30.0
+2.35.1
 


### PR DESCRIPTION
Updated version and hashes, also reapplied the necessary patches.

Opening attached files needs to be tested. I disabled `/tmp` access as the
necessary patch is included.

cc #87