### PR TITLE
Remove D-Bus gvfs access

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -43,8 +43,6 @@ finish-args:
     # - --filesystem=xdg-config
     # Network filesystems
   - --filesystem=xdg-run/gvfs
-  - --talk-name=org.gtk.vfs
-  - --talk-name=org.gtk.vfs.*
 cleanup:
   - '*.a'
   - '*.h'


### PR DESCRIPTION
As per https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access
remove access to gvfs daemons, as KeePassXC doesn't use it, and remove
access to the org.gtk.vfs D-Bus name as it never existed.

Note that this doesn't stop KeePassXC from accessing remote shares that
gvfs exports over fuse.