### PR TITLE
Fix databases autolock when the user session is locked

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -13,8 +13,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
     # Screen Lock Listener
   - --talk-name=org.freedesktop.ScreenSaver
-  - --talk-name=org.freedesktop.login1.Manager
-  - --talk-name=org.freedesktop.login1.Session
+  - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.gnome.ScreenSaver
   - --talk-name=org.gnome.SessionManager
   - --talk-name=org.gnome.SessionManager.Presence


### PR DESCRIPTION
Fixes #107.

`systemd-logind` uses the standard DBus interface `org.freedesktop.login1` to inform about locked session events. The mentioned interface is registered in the system DBus session. Unfortunately, the flatpak permissions for KPXC are not correctly set, hence KPXC won't never know that a session got locked and in turn it never locks open databases.