### PR TITLE
add smartcard permission to support Nitrokey 3

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -26,6 +26,8 @@ finish-args:
   - --share=network
     # YubiKey USB access
   - --device=all
+    # Nitrokey Smartcard access
+  - --socket=pcsc
     # SSH Agent access
   - --socket=ssh-auth
   - --env=SSH_AUTH_SOCK=$SSH_AUTH_SOCK


### PR DESCRIPTION
This permission is necessary to use the Nitrokey support for `Nitrokey 3a mini` added in version 2.7.6 (https://github.com/keepassxreboot/keepassxc/pull/9631).