### PR TITLE
Update pcsc-lite to 2.3.3 for compatibility with newer systems

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -139,11 +139,12 @@ modules:
       - name: pcsclite
         config-opts:
           - --sbindir=/app/bin
+          - --disable-polkit
         sources:
           - type: git
             url: https://github.com/LudovicRousseau/PCSC
-            tag: 2.0.0
-            commit: 549922c1355fdd1e85eb0a952fefda7bb96e286a
+            tag: 2.3.3
+            commit: 3ef55e02979de6834015b380c1d21671eeb4e9f5
         cleanup:
           - /bin
         post-install:


### PR DESCRIPTION
- Updates `pcsc-lite` from `2.0.0` to `2.3.3` for compatibility with newer systems
- Adds `--disable-polkit` to avoid polkit build dependency in newer `pcsc-lite` versions
- Fixes smart card detection issues on systems with `pcsc-lite` `2.3.x`