### PR TITLE
Revert "Update pcsc-lite to 2.3.3 for compatibility with newer systems"

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -139,12 +139,11 @@ modules:
       - name: pcsclite
         config-opts:
           - --sbindir=/app/bin
-          - --disable-polkit
         sources:
           - type: git
             url: https://github.com/LudovicRousseau/PCSC
-            tag: 2.3.3
-            commit: 3ef55e02979de6834015b380c1d21671eeb4e9f5
+            tag: 2.0.0
+            commit: 549922c1355fdd1e85eb0a952fefda7bb96e286a
         cleanup:
           - /bin
         post-install:


### PR DESCRIPTION
This reverts commit 19123879cf53dea2803a4baa384701852db47698.

Unfortunately, PCSC updated the API in version 2.3.0 and it is NOT backwards compatible. This means bridging from an updated Flatpak environment will break if the underlying system is not running 2.3.x. This breaks nitrokey and NFC integration in KeePassXC on a lot of platforms.

See https://github.com/keepassxreboot/keepassxc/issues/12470#issuecomment-3325726131 and https://github.com/LudovicRousseau/PCSC/issues/199