### PR TITLE
Update runtime to 5.15-25.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -1,6 +1,6 @@
 id: org.keepassxc.KeePassXC
 runtime: org.kde.Platform
-runtime-version: '5.15-24.08'
+runtime-version: '5.15-25.08'
 sdk: org.kde.Sdk
 command: keepassxc-wrapper
 finish-args:
@@ -81,9 +81,6 @@ modules:
       - /share/man
 
     modules:
-
-      - shared-modules/libusb/libusb.json
-
       - name: minizip
         subdir: contrib/minizip
         sources:
@@ -164,3 +161,11 @@ modules:
             sha256: 52208807f237dfa0ca29882f8b13d60b820496116ad191cf197ca56f2b7fddf3
         cleanup:
           - '*'
+        modules:
+          - name: ruby
+            sources:
+              - type: archive
+                url: https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.7.tar.gz
+                sha256: 23815a6d095696f7919090fdc3e2f9459b2c83d57224b2e446ce1f5f7333ef36
+            cleanup:
+              - '*'


### PR DESCRIPTION
`libusb` is in the runtime now, so `shared-modules` can be removed

`ruby` got removed from the runtime and is required for `asciidoctor`

Resubmission of #149 with clean commit history