### PR TITLE
Bump to 2.7.11 and update runtime to 5.15-25.08

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/keepassxc-desktop-xml.patch
+++ b/keepassxc-desktop-xml.patch
@@ -1,0 +1,20 @@
+diff --git a/share/linux/org.keepassxc.KeePassXC.appdata.xml b/share/linux/org.keepassxc.KeePassXC.appdata.xml
+index 624be16..c9ba1ba 100644
+--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
++++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
+@@ -47,6 +47,7 @@
+   <releases>
+     <release version="2.7.11" date="2025-11-23" type="stable">
+       <description>
++      <ul>
+         <li>Add image, HTML, Markdown preview, and text editing support to inline attachment viewer [#12085, #12244, #12654]</li>
+         <li>Add database merge confirmation dialog [#10173]</li>
+         <li>Add option to auto-generate a password for new entries [#12593]</li>
+@@ -110,6 +111,7 @@
+         <li>Windows: Remove broken check for MSVC Redistributable from MSI installer [#11950]</li>
+         <li>Linux: Fix startup delay due to StartupNotify setting in desktop file [#12306]</li>
+         <li>Linux: Fix memory initialisation when --pw-stdin is used with a pipe [#12050]</li>
++      </ul>
+       </description>
+     </release>
+     <release version="2.7.10" date="2025-03-02" type="stable">

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -1,6 +1,6 @@
 id: org.keepassxc.KeePassXC
 runtime: org.kde.Platform
-runtime-version: '5.15-24.08'
+runtime-version: '5.15-25.08'
 sdk: org.kde.Sdk
 command: keepassxc-wrapper
 finish-args:
@@ -81,9 +81,6 @@ modules:
       - /share/man
 
     modules:
-
-      - shared-modules/libusb/libusb.json
-
       - name: minizip
         subdir: contrib/minizip
         sources:
@@ -164,3 +161,11 @@ modules:
             sha256: 52208807f237dfa0ca29882f8b13d60b820496116ad191cf197ca56f2b7fddf3
         cleanup:
           - '*'
+        modules:
+          - name: ruby
+            sources:
+              - type: archive
+                url: https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.7.tar.gz
+                sha256: 23815a6d095696f7919090fdc3e2f9459b2c83d57224b2e446ce1f5f7333ef36
+            cleanup:
+              - '*'

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -69,8 +69,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/keepassxreboot/keepassxc.git
-        tag: 2.7.10
-        commit: b342be457153aa098c8bbce0f8b0fd3baa8c158f
+        tag: 2.7.11
+        commit: 01e5b6ee1d3e8fdef203505c645962696cb8d97c
+      - type: patch
+        path: keepassxc-desktop-xml.patch
     post-install:
       - install -Dm755 ./utils/keepassxc-flatpak-wrapper.sh /app/bin/keepassxc-wrapper
       - |


### PR DESCRIPTION
libusb is in the runtime now, so shared-modules can be removed

ruby got removed from the runtime and is required for asciidoctor

Resubmission of https://github.com/flathub/org.keepassxc.KeePassXC/pull/149 with clean commit history

runtime update provided by @PunkPangolin
