### PR TITLE
Reduce attack surface via socket permissions

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -6,7 +6,7 @@ command: keepassxc-wrapper
 finish-args:
     # X11 + XShm access
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
     # Wayland access
   - --socket=wayland
     # Notification access


### PR DESCRIPTION
This is a relatively simple change that I believe is altogether agreeable. What this does is that we change our permission of x11 to fallback-x11 making the X11 socket available only if there is no Wayland socket.
Therefore the application can only be hypothetically attacked via X11 if on an X11 session and will otherwise be under Wayland and thus not a target via X11. There may be some blockers on this I have yet to find, but I believe this should be left open and such simply marked as blocked by "thing" as this will result in a net gain in security. Furthermore, KeepassXC uses the KDE SDK and as KDE is moving to drop X11 support, our default being to expose only Wayland if on a Wayland session is not unwarranted - if anything we're providing more support than we need to by supporting fallback to X11 still.  
There is no issue with us supporting X11, just that we shouldn't expose it without reason as we support Wayland proper.