### PR TITLE
Tighten up permissions

### DIFF
--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -4,11 +4,11 @@ runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: keepassxc-wrapper
 finish-args:
-    # X11 + XShm access
-  - --share=ipc
-  - --socket=x11
     # Wayland access
   - --socket=wayland
+    # Fallback X11 + XShm access
+  - --share=ipc
+  - --socket=fallback-x11
     # Notification access
   - --talk-name=org.freedesktop.Notifications
     # Screen Lock Listener

--- a/org.keepassxc.KeePassXC.yml
+++ b/org.keepassxc.KeePassXC.yml
@@ -30,18 +30,12 @@ finish-args:
   - --socket=pcsc
     # SSH Agent access
   - --socket=ssh-auth
-  - --env=SSH_AUTH_SOCK=$SSH_AUTH_SOCK
-    # Host access: workaround extensive portal issues
-    # (use beta branch for testing of portals based file access)
-  - --filesystem=host
     # Access to temporary files (Remove if RuntimeDirectory patch is upstreamed)
   - --filesystem=/tmp
     # Required for native messaging (Tor browser)
-    # TODO uncomment when host access is no longer required.
-    # - --filesystem=xdg-data
+  - --filesystem=xdg-data
     # Required for native messaging (Non-Firefox)
-    # TODO uncomment when host access is no longer required.
-    # - --filesystem=xdg-config
+  - --filesystem=xdg-config
     # Network filesystems
   - --filesystem=xdg-run/gvfs
 cleanup:


### PR DESCRIPTION
### Changes

* `--socket=ssh-auth` already does `--env=SSH_AUTH_SOCK=$SSH_AUTH_SOCK`, so the latter is not necessary. 
* `--filesystem=host` has been removed in favor of portal-based file access. Both `--filesystem=xdg-data` and `--filesystem=xdg-config` are enabled as well. 

### Possible todos
* Remove these:
  ```
  org.gnome.ScreenSaver
  org.gnome.SessionManager
  org.gnome.SessionManager.Presence
  com.canonical.Unity.Session
  ```
  and leave only `org.freedesktop.ScreenSaver` (or maybe `org.freedesktop.portal.Inhibit`) and `org.freedesktop.login1`, but it seems upstream source requires some changes to accommodate that.